### PR TITLE
ignore .pyc files for git as well as userinterfacestate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.pyc
+UserInterfaceState.xcuserstate


### PR DESCRIPTION
userinterfacestate changes everytime you click on something or resize a window - things that don't matter to the integrity of an Xcode project but are annoying if you're trying to use git.