### PR TITLE
Add free automated flake8 testing of pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+cache: pip
+python:
+    - "2.7"
+    - "3.6"
+matrix:
+    allow_failures:
+        - python: "3.6"
+install:
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The owner of the this repo would need to go to https://travis-ci.com/profile and flip the repository switch __on__ to enable free automated flake8 testing of each pull request.

Output will look like: https://travis-ci.org/cclauss/itinerant-tester/builds/283107093